### PR TITLE
Remove base64, add set -e and new shell style

### DIFF
--- a/decrypt.sh
+++ b/decrypt.sh
@@ -31,7 +31,7 @@ b2 download_file_by_name $BUCKET_NAME $FILE_TO_DECRYPT.key.enc \
 # the filesystem.
 
 openssl rsautl -decrypt -inkey $PRIVATE_KEY -in $FILE_TO_DECRYPT.key.enc | \
-	openssl enc -aes-256-cbc -d -a -pass stdin -in \
+	openssl enc -aes-256-cbc -d -pass stdin -in \
 	$FILE_TO_DECRYPT.enc -out $FILE_TO_DECRYPT 
 
 

--- a/encrypt.sh
+++ b/encrypt.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 PUBLIC_KEY="pub-key.pem"
 FILE_TO_ENCRYPT="$@"
 B2_BUCKET_NAME="b2demo"
@@ -14,13 +16,13 @@ fi
 # Generate a one-time per file password that's 180 characters long. Save it
 # into RAM only for use by subsequent commands.
 
-ONE_TIME_PASSWORD=`openssl rand -base64 180`
+ONE_TIME_PASSWORD=$(openssl rand -base64 180)
 
 # Now, encrypt the file. The file is encrypted using symmetrical 
 # encryption along with the 180 character one-time password above. 
 
 echo $ONE_TIME_PASSWORD | \
-	openssl aes-256-cbc -a -salt -pass stdin \
+	openssl aes-256-cbc -salt -pass stdin \
 	-in $FILE_TO_ENCRYPT -out $FILE_TO_ENCRYPT.enc
 
 # Now, encrypt the 180 character one-time password using your public key. This


### PR DESCRIPTION
Hi!

Related to https://github.com/Backblaze-B2-Samples/encryption/issues/2 this removes the unnecessary base64 overhead. 

Adding set -e so that the script aborts if it encounters errors.

Migrating `` to the new $() bash style.