### PR TITLE
If the previous upload did not succeed remove it

### DIFF
--- a/encrypt.sh
+++ b/encrypt.sh
@@ -36,3 +36,4 @@ echo $ONE_TIME_PASSWORD | \
 b2 upload_file $B2_BUCKET_NAME $FILE_TO_ENCRYPT.enc $FILE_TO_ENCRYPT.enc
 b2 upload_file $B2_BUCKET_NAME $FILE_TO_ENCRYPT.key.enc \
 	$FILE_TO_ENCRYPT.key.enc
+b2 cancel-all-unfinished-large-files $B2_BUCKET_NAME


### PR DESCRIPTION
When the previous upload encountered any form of error it is marked as 0 Bytes. So we can simply remove it.

https://www.backblaze.com/b2/docs/b2_cancel_large_file.html